### PR TITLE
[DAY7] SSG 적용하기 (with 데이터 페칭)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,28 @@
-# onebite-cinema
+<div align="center">
 
-한입 FE 커뮤니티에서 운영하는 <[한입 FE 챌린지 - 2기](https://winterlood.notion.site/FE-2-69911cc53e8e454ab7574df2c6f76c0a)>에 참여하며 실습한 내용입니다. <br />
-인프런 강의 <[한 입 크기로 잘라먹는 Next.js (15+) - winterlood](https://www.inflearn.com/course/%ED%95%9C%EC%9E%85-%ED%81%AC%EA%B8%B0-nextjs)>의 완주와 함께 진행됩니다.
+# 한입 🧑‍🍳 씨네마
 
 ![진행 기간](https://img.shields.io/badge/진행%20기간-2024.09.09%20--%2010.05-1A1C2B)<br />
 
 ![Next.js](https://img.shields.io/badge/Next.js-000000?style=flat&logo=Next.js&logoColor=white) ![Typescript](https://img.shields.io/badge/Typescript-3178C6?style=flat&logo=Typescript&logoColor=white) <br />
+
+<div>
+
+한입 FE 커뮤니티에서 운영하는 <br />
+<**[한입 FE 챌린지 - 2기](https://winterlood.notion.site/FE-2-69911cc53e8e454ab7574df2c6f76c0a)**> 에 참여하며 실습한 내용입니다.
+
+</div>
+
+<div>
+
+인프런 강의 <[한 입 크기로 잘라먹는 Next.js (15+) - winterlood](https://www.inflearn.com/course/%ED%95%9C%EC%9E%85-%ED%81%AC%EA%B8%B0-nextjs)>의 완주와 함께 진행됩니다.
+
+</div>
+
+<div>
+
+미션 상세 내용 보기 >> **[PR](https://github.com/sryung1225/onebite-cinema/pulls?q=is%3Apr+is%3Aclosed)** 🧑‍🍳
+
+</div>
+
+</div>

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,14 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ["media.themoviedb.org", "*"],
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "media.themoviedb.org",
+        port: "",
+        pathname: "**",
+      },
+    ],
   },
   reactStrictMode: true,
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,11 +1,11 @@
 import { ReactNode } from "react";
-import { InferGetServerSidePropsType } from "next";
+import { InferGetStaticPropsType } from "next";
 import SearchableLayout from "@/components/searchable-layout";
 import MovieItem from "@/components/movie-item";
 import fetchMovies from "@/lib/fetch-movies";
 import fetchRandomMovies from "@/lib/fetch-random-movies";
 
-export const getServerSideProps = async () => {
+export const getStaticProps = async () => {
   const [allMovies, recoMovies] = await Promise.all([
     fetchMovies(),
     fetchRandomMovies(),
@@ -21,7 +21,7 @@ export const getServerSideProps = async () => {
 export default function Home({
   allMovies,
   recoMovies,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   return (
     <div className="flex flex-col gap-5">
       <section className="mt-5">

--- a/src/pages/movie/[id].tsx
+++ b/src/pages/movie/[id].tsx
@@ -1,12 +1,26 @@
-import { GetServerSidePropsContext, InferGetServerSidePropsType } from "next";
+import { GetStaticPropsContext, InferGetStaticPropsType } from "next";
+import { useRouter } from "next/router";
 import Image from "next/image";
 import fetchOneMovie from "@/lib/fetch-one-movie";
 
-export const getServerSideProps = async (
-  context: GetServerSidePropsContext
-) => {
+export const getStaticPaths = () => {
+  return {
+    paths: [
+      { params: { id: "1" } },
+      { params: { id: "2" } },
+      { params: { id: "3" } },
+    ],
+    fallback: true,
+    // false: 404 NotFound
+    // blocking: SSR 방식
+    // true: SSR 방식 + 데이터가 없는 폴백 상태 페이지부터 반환
+  };
+};
+
+export const getStaticProps = async (context: GetStaticPropsContext) => {
   const id = context.params!.id;
   const movie = await fetchOneMovie(Number(id));
+  if (!movie) return { notFound: true };
   return {
     props: {
       movie,
@@ -16,9 +30,10 @@ export const getServerSideProps = async (
 
 export default function Page({
   movie,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+}: InferGetStaticPropsType<typeof getStaticProps>) {
+  const router = useRouter();
+  if (router.isFallback) return "로딩중입니다";
   if (!movie) return "문제가 발생했습니다. 다시 시도하세요";
-
   const {
     title,
     subTitle,

--- a/src/pages/movie/[id].tsx
+++ b/src/pages/movie/[id].tsx
@@ -1,19 +1,16 @@
 import { GetStaticPropsContext, InferGetStaticPropsType } from "next";
 import { useRouter } from "next/router";
 import Image from "next/image";
+import fetchMovies from "@/lib/fetch-movies";
 import fetchOneMovie from "@/lib/fetch-one-movie";
 
-export const getStaticPaths = () => {
+export const getStaticPaths = async () => {
+  const movies = await fetchMovies();
   return {
-    paths: [
-      { params: { id: "1" } },
-      { params: { id: "2" } },
-      { params: { id: "3" } },
-    ],
+    paths: movies.map(({ id }) => ({
+      params: { id: id.toString() },
+    })),
     fallback: true,
-    // false: 404 NotFound
-    // blocking: SSR 방식
-    // true: SSR 방식 + 데이터가 없는 폴백 상태 페이지부터 반환
   };
 };
 

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,27 +1,22 @@
-import { ReactNode } from "react";
-import { GetServerSidePropsContext, InferGetServerSidePropsType } from "next";
+import { ReactNode, useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import SearchableLayout from "@/components/searchable-layout";
 import MovieItem from "@/components/movie-item";
 import fetchMovies from "@/lib/fetch-movies";
+import { MovieData } from "@/types";
 
-export const getServerSideProps = async (
-  context: GetServerSidePropsContext
-) => {
-  const q = context.query.q;
-  const movies = await fetchMovies(q as string);
-  return {
-    props: {
-      movies,
-    },
-  };
-};
-
-export default function Page({
-  movies,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+export default function Page() {
   const router = useRouter();
   const { q } = router.query;
+
+  const [movies, setMovies] = useState<MovieData[]>([]);
+  useEffect(() => {
+    const fetchSearchResult = async () => {
+      const data = await fetchMovies(q as string);
+      setMovies(data);
+    };
+    if (q) fetchSearchResult();
+  }, [q]);
 
   return q ? (
     <ul className="grid grid-cols-3 gap-2 mt-5">


### PR DESCRIPTION
## 미션) 한입-씨네마 SSG 적용하기 (with 데이터 페칭)
"한입 씨네마" 프로젝트의 일부 페이지를 SSG 방식으로 동작하도록 변경합니다.

- [x] 인덱스 페이지
 - 전체 영화와 추천 영화 모두 실시간으로 변화하는 데이터가 없기에 SSG 사용시 더 빠른 사용자 경험 제공 가능
- [x] 서치 페이지
 - 실시간 변화 데이터 없음
 - 다만, query string을 통해 전달되는 검색어를 빌드타임에서 알 수 없다는 문제가 있어 데이터 페칭은 뒤에 진행해야 함
 - 💡 레이아웃만 SSG를 통해 사전 렌더링 + 마운트 이후, 검색어에 접근해 데이터 페칭
- [x] 영화 상세 페이지
 - 실시간 변화 데이터 없음
 - 💡 동적 경로 페이지에 SSG 방식을 적용하기 위해 경로에 대한 사전 정보 `paths`를 제공
 - 💡 `fallback`으로 사전에 전달되지 않는 경로에 대한 대처 적용. `true`를 선택해 데이터가 없는 경우의 페이지를 우선 렌더링

### 기타 작업
- [x] next/image 사용을 위해 지정한 config domains를 remotePatterns로 변경 (next 14 권장 사항)
- [x] 모든 영화 상세 페이지 사전 렌더링 적용