### PR TITLE
[DAY12] 데이터 페칭 구현하기

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  logging: {
+    fetches: {
+      fullUrl: true,
+    },
+  },
   images: {
     remotePatterns: [
       {

--- a/src/app/(searchable)/page.tsx
+++ b/src/app/(searchable)/page.tsx
@@ -1,5 +1,37 @@
 import MovieItem from "@/components/movie-item";
-import movies from "@/mock/movies.json";
+import { MovieData } from "@/types";
+
+async function AllMovies() {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_SERVER}/movie`);
+  if (!response.ok) {
+    return <div>오류가 발생했습니다...</div>;
+  }
+  const allMovies: MovieData[] = await response.json();
+  return (
+    <>
+      {allMovies.map((movie) => (
+        <MovieItem key={`allmovies-${movie.id}`} {...movie} />
+      ))}
+    </>
+  );
+}
+
+async function RecoMovies() {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_SERVER}/movie/random`
+  );
+  if (!response.ok) {
+    return <div>오류가 발생했습니다...</div>;
+  }
+  const recoMovies: MovieData[] = await response.json();
+  return (
+    <>
+      {recoMovies.map((movie) => (
+        <MovieItem key={`recomovies-${movie.id}`} {...movie} />
+      ))}
+    </>
+  );
+}
 
 export default function Home() {
   return (
@@ -8,17 +40,13 @@ export default function Home() {
         <section className="mt-5">
           <h2 className="mb-2 text-2xl font-bold">지금 가장 추천하는 영화</h2>
           <ul className="grid grid-cols-3 gap-2">
-            {movies.slice(0, 3).map((movie) => (
-              <MovieItem key={`recomovies-${movie.id}`} {...movie} />
-            ))}
+            <RecoMovies />
           </ul>
         </section>
         <section className="mt-5">
           <h2 className="mb-2 text-2xl font-bold">등록된 모든 영화</h2>
           <ul className="grid grid-cols-5 gap-2">
-            {movies.map((movie) => (
-              <MovieItem key={`allmovies-${movie.id}`} {...movie} />
-            ))}
+            <AllMovies />
           </ul>
         </section>
       </div>

--- a/src/app/(searchable)/page.tsx
+++ b/src/app/(searchable)/page.tsx
@@ -1,15 +1,12 @@
 import MovieItem from "@/components/movie-item";
+import fetchData from "@/lib/fetch-data";
 import { MovieData } from "@/types";
 
 async function AllMovies() {
-  const response = await fetch(`${process.env.NEXT_PUBLIC_SERVER}/movie`);
-  if (!response.ok) {
-    return <div>오류가 발생했습니다...</div>;
-  }
-  const allMovies: MovieData[] = await response.json();
+  const movies = await fetchData<MovieData[]>(`movie`, []);
   return (
     <>
-      {allMovies.map((movie) => (
+      {movies.map((movie) => (
         <MovieItem key={`allmovies-${movie.id}`} {...movie} />
       ))}
     </>
@@ -17,16 +14,10 @@ async function AllMovies() {
 }
 
 async function RecoMovies() {
-  const response = await fetch(
-    `${process.env.NEXT_PUBLIC_SERVER}/movie/random`
-  );
-  if (!response.ok) {
-    return <div>오류가 발생했습니다...</div>;
-  }
-  const recoMovies: MovieData[] = await response.json();
+  const movies = await fetchData<MovieData[]>(`movie/random`, []);
   return (
     <>
-      {recoMovies.map((movie) => (
+      {movies.map((movie) => (
         <MovieItem key={`recomovies-${movie.id}`} {...movie} />
       ))}
     </>

--- a/src/app/(searchable)/page.tsx
+++ b/src/app/(searchable)/page.tsx
@@ -3,7 +3,7 @@ import fetchData from "@/lib/fetch-data";
 import { MovieData } from "@/types";
 
 async function AllMovies() {
-  const movies = await fetchData<MovieData[]>(`movie`, []);
+  const movies = await fetchData<MovieData[]>(`movie`, [], "force-cache");
   return (
     <>
       {movies.map((movie) => (
@@ -14,7 +14,9 @@ async function AllMovies() {
 }
 
 async function RecoMovies() {
-  const movies = await fetchData<MovieData[]>(`movie/random`, []);
+  const movies = await fetchData<MovieData[]>(`movie/random`, [], {
+    revalidate: 10,
+  });
   return (
     <>
       {movies.map((movie) => (

--- a/src/app/(searchable)/search/page.tsx
+++ b/src/app/(searchable)/search/page.tsx
@@ -1,12 +1,19 @@
 import React from "react";
-import movies from "@/mock/movies.json";
 import MovieItem from "@/components/movie-item";
+import { MovieData } from "@/types";
 
-export default function Page({
+export default async function Page({
   searchParams,
 }: {
   searchParams: { q?: string };
 }) {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_SERVER}/movie/search?q=${searchParams.q || ""}`
+  );
+  if (!response.ok) {
+    return <div>오류가 발생했습니다...</div>;
+  }
+  const movies: MovieData[] = await response.json();
   return (
     <>
       {movies.length > 0 ? (

--- a/src/app/(searchable)/search/page.tsx
+++ b/src/app/(searchable)/search/page.tsx
@@ -1,19 +1,17 @@
 import React from "react";
 import MovieItem from "@/components/movie-item";
 import { MovieData } from "@/types";
+import fetchData from "@/lib/fetch-data";
 
 export default async function Page({
   searchParams,
 }: {
   searchParams: { q?: string };
 }) {
-  const response = await fetch(
-    `${process.env.NEXT_PUBLIC_SERVER}/movie/search?q=${searchParams.q || ""}`
+  const movies = await fetchData<MovieData[]>(
+    `movie/search?q=${searchParams.q || ""}`,
+    []
   );
-  if (!response.ok) {
-    return <div>오류가 발생했습니다...</div>;
-  }
-  const movies: MovieData[] = await response.json();
   return (
     <>
       {movies.length > 0 ? (

--- a/src/app/(searchable)/search/page.tsx
+++ b/src/app/(searchable)/search/page.tsx
@@ -10,7 +10,8 @@ export default async function Page({
 }) {
   const movies = await fetchData<MovieData[]>(
     `movie/search?q=${searchParams.q || ""}`,
-    []
+    [],
+    "force-cache"
   );
   return (
     <>

--- a/src/app/movie/[id]/page.tsx
+++ b/src/app/movie/[id]/page.tsx
@@ -8,7 +8,11 @@ export default async function Page({
 }: {
   params: { id: string | string[] };
 }) {
-  const movie = await fetchData<MovieData | null>(`movie/${params.id}`, null);
+  const movie = await fetchData<MovieData | null>(
+    `movie/${params.id}`,
+    null,
+    "force-cache"
+  );
   return (
     <div className="flex flex-col gap-5">
       {movie ? (

--- a/src/app/movie/[id]/page.tsx
+++ b/src/app/movie/[id]/page.tsx
@@ -1,13 +1,19 @@
 import React from "react";
-import movies from "@/mock/movies.json";
 import Image from "next/image";
+import { MovieData } from "@/types";
 
-export default function Page({
+export default async function Page({
   params,
 }: {
   params: { id: string | string[] };
 }) {
-  const movie = movies[0];
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_SERVER}/movie/${params.id}`
+  );
+  if (!response.ok) {
+    return <div>오류가 발생했습니다...</div>;
+  }
+  const movie: MovieData = await response.json();
   return (
     <div className="flex flex-col gap-5">
       <div

--- a/src/app/movie/[id]/page.tsx
+++ b/src/app/movie/[id]/page.tsx
@@ -1,50 +1,51 @@
 import React from "react";
 import Image from "next/image";
 import { MovieData } from "@/types";
+import fetchData from "@/lib/fetch-data";
 
 export default async function Page({
   params,
 }: {
   params: { id: string | string[] };
 }) {
-  const response = await fetch(
-    `${process.env.NEXT_PUBLIC_SERVER}/movie/${params.id}`
-  );
-  if (!response.ok) {
-    return <div>오류가 발생했습니다...</div>;
-  }
-  const movie: MovieData = await response.json();
+  const movie = await fetchData<MovieData | null>(`movie/${params.id}`, null);
   return (
     <div className="flex flex-col gap-5">
-      <div
-        className={`relative flex justify-center p-5 bg-center bg-no-repeat bg-cover before:content-[''] before:absolute before:top-0 before:left-0 before:w-full before:h-full before:bg-black before:opacity-70 `}
-        style={{ backgroundImage: `url('${movie.posterImgUrl}')` }}
-      >
-        <Image
-          src={movie.posterImgUrl}
-          alt={`영화 <${movie.title}> 포스터`}
-          width="300"
-          height="350"
-          className="z-10 w-auto max-h-[350px] h-full"
-        />
-      </div>
-      <div className="flex flex-col gap-2">
-        <h2 className="text-4xl font-bold">{movie.title}</h2>
-        <span>{movie.company}</span>
-        <dl className="flex">
-          <dt className="a11yHidden">개봉일</dt>
-          <dd className="after:content-['|'] after:px-2">
-            {movie.releaseDate}
-          </dd>
-          <dt className="a11yHidden">장르</dt>
-          <dd className="after:content-['|'] after:px-2">{movie.genres}</dd>
-          <dt className="a11yHidden">상영시간</dt>
-          <dd>{movie.runtime}분</dd>
-        </dl>
-        <hr className="my-5" />
-        <h3 className="font-bold">{movie.subTitle}</h3>
-        <p className="leading-6">{movie.description}</p>
-      </div>
+      {movie ? (
+        <>
+          <div
+            className={`relative flex justify-center p-5 bg-center bg-no-repeat bg-cover before:content-[''] before:absolute before:top-0 before:left-0 before:w-full before:h-full before:bg-black before:opacity-70 `}
+            style={{ backgroundImage: `url('${movie.posterImgUrl}')` }}
+          >
+            <Image
+              src={movie.posterImgUrl}
+              alt={`영화 <${movie.title}> 포스터`}
+              width="300"
+              height="350"
+              className="z-10 w-auto max-h-[350px] h-full"
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <h2 className="text-4xl font-bold">{movie.title}</h2>
+            <span>{movie.company}</span>
+            <dl className="flex">
+              <dt className="a11yHidden">개봉일</dt>
+              <dd className="after:content-['|'] after:px-2">
+                {movie.releaseDate}
+              </dd>
+              <dt className="a11yHidden">장르</dt>
+              <dd className="after:content-['|'] after:px-2">{movie.genres}</dd>
+              <dt className="a11yHidden">상영시간</dt>
+              <dd>{movie.runtime}분</dd>
+            </dl>
+            <hr className="my-5" />
+            <h3 className="font-bold">{movie.subTitle}</h3>
+            <p className="leading-6">{movie.description}</p>
+          </div>
+        </>
+      ) : (
+        <div>문제가 발생했습니다. 다시 시도하세요.</div>
+      )}
     </div>
   );
 }

--- a/src/lib/fetch-data.ts
+++ b/src/lib/fetch-data.ts
@@ -1,10 +1,18 @@
+type CacheOption =
+  | "no-store"
+  | "force-cache"
+  | { revalidate?: number; tags?: string[] };
+
 export default async function fetchData<T>(
   endpoint: string,
-  fallback: T
+  fallback: T,
+  cache: CacheOption = "no-store"
 ): Promise<T> {
   const url = `${process.env.NEXT_PUBLIC_SERVER}/${endpoint}`;
+  const cacheOption =
+    typeof cache === "string" ? { cache } : { next: { ...cache } };
   try {
-    const response = await fetch(url);
+    const response = await fetch(url, cacheOption);
     if (!response.ok) {
       throw new Error("⚠️ 오류가 발생했습니다.");
     }

--- a/src/lib/fetch-data.ts
+++ b/src/lib/fetch-data.ts
@@ -1,0 +1,16 @@
+export default async function fetchData<T>(
+  endpoint: string,
+  fallback: T
+): Promise<T> {
+  const url = `${process.env.NEXT_PUBLIC_SERVER}/${endpoint}`;
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error("⚠️ 오류가 발생했습니다.");
+    }
+    return await response.json();
+  } catch (err) {
+    console.error(err);
+    return fallback;
+  }
+}


### PR DESCRIPTION
## 미션) 한입-씨네마 데이터 페칭 구현하기!
"한입 씨네마" 프로젝트의 데이터 페칭을 실제로 구현해봅니다.
- 적어도 인덱스, 무비 페이지의 데이터 페칭은 서버측에서 이루어져야 합니다. 서치 페이지의 데이터 페칭은 자유롭게 만들어주셔도 됩니다.
- 각 페이지의 데이터 페칭 별로 적절한 캐시 옵션을 설정해주세요.
<br />

- [x] 1. 인덱스 페이지 데이터 페칭 구현하기
  - 모든 영화 (/movie) : force-cache : 모든 영화 데이터가 변화하지 않기 때문에 영구 캐싱 적용
  - 추천 영화 (/movie/random) : revalidate : 호출마다 변화하는 데이터이기 때문에 10초 주기로 업데이트하는 캐싱 적용
- [x] 2. 서치 페이지 데이터 페칭 구현하기
  - 검색 영화 (/movie/search) : force-cache : 모든 영화와 마찬가지로 변화하지 않는 데이터
- [x] 3. 영화 상세 페이지 데이터 페칭 구현하기
  - 영화 상세 (/movie/[id]) : force-cache : 모든 영화와 마찬가지로 변화하지 않는 데이터

### 결과 화면 캡쳐
![화면 기록 2024-11-01 오후 5 29 43](https://github.com/user-attachments/assets/dda30552-cd00-4cfd-bb88-4f1af02b35c9)

### 학습 내용 포스팅
[[NEXT] App Router의 데이터 캐시에 대해 정리하며 이해하기](https://s-ryung.tistory.com/120)